### PR TITLE
DTD-872: Adds method to override url for taxpayer endpoint

### DIFF
--- a/app/uk/gov/hmrc/debttransformationstub/controllers/DebtManagementAPITestController.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/controllers/DebtManagementAPITestController.scala
@@ -71,7 +71,7 @@ class DebtManagementAPITestController @Inject() (
 
   def getTaxpayerData(idKey: String): Action[AnyContent] = Action.async { request =>
     if (appConfig.isPollingEnv)
-      pollingService.insertRequestAndServeResponse(Json.obj(), request.uri).map {
+      pollingService.insertTaxpayerRequestAndServeResponse(Json.obj()).map {
         case Some(response) => Status(response.status.getOrElse(200))(response.content)
         case None => ServiceUnavailable
       }

--- a/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
@@ -40,7 +40,7 @@ class DebtManagementAPIPollingService @Inject() (
   def insertTaxpayerRequestAndServeResponse(
                                              request: JsValue
                                            ): Future[Option[RequestDetail]] =
-    process(request, uri = None, uriOverride = Some("/subcontractor/idms/taxpayer/789"))
+    process(request, uri = None, uriOverride = Some("/individuals/subcontractor/idms/taxpayer/789"))
 
   def insertRequestAndServeResponse(
     request: JsValue,

--- a/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
@@ -37,6 +37,11 @@ class DebtManagementAPIPollingService @Inject() (
                                    ): Future[Option[RequestDetail]] =
     process(request, uri = None, uriOverride = Some("/individuals/field-collections/charges"))
 
+  def insertTaxpayerRequestAndServeResponse(
+                                             request: JsValue
+                                           ): Future[Option[RequestDetail]] =
+    process(request, uri = None, uriOverride = Some("/subcontractor/idms/taxpayer/789"))
+
   def insertRequestAndServeResponse(
     request: JsValue,
     uri: String


### PR DESCRIPTION
API endpoint needs publishing in QA, this method allows the endpoint to be overridden when polling