### PR TITLE
DTD-1125: Bridge tool - Skip calling service in QA and use EIS API directly

### DIFF
--- a/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
@@ -63,7 +63,7 @@ class DebtManagementAPIPollingService @Inject()(
     process(
       Json.obj(),
       uri = None,
-      uriOverride = Some("/individuals/subcontractor/idms/taxpayer/789"),
+      uriOverride = Some("/individuals/subcontractor/idms/taxpayer/789"), //TODO: Remove override when https://admin.qa.tax.service.gov.uk/ifs/individuals/subcontractor/idms/wmfid/789 is used
       method = Some("GET")
     )
 

--- a/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingService.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.debttransformationstub.repositories.TTPRequestsRepository
 import play.api.libs.json.Json
 
 @Singleton
-class DebtManagementAPIPollingService @Inject() (
+class DebtManagementAPIPollingService @Inject()(
   ttpRequestsRepository: TTPRequestsRepository,
   appConfig: AppConfig
 ) {
@@ -36,24 +36,26 @@ class DebtManagementAPIPollingService @Inject() (
   def insertFCChargeRequestAndServeResponse(
     request: JsValue,
     correlationId: String,
-    method: String
+    method: String,
+    uri: String
   ): Future[Option[RequestDetail]] =
     process(
       request,
-      uri = None,
-      uriOverride = Some("/individuals/field-collections/charges"),
+      uri = Some(uri),
+      uriOverride = None,
       headers = Map("CorrelationId" -> correlationId),
       method = Some(method.toUpperCase)
     )
 
   def insertTemplateRequestAndServeResponse(
     request: JsValue,
-    correlationId: String
+    correlationId: String,
+    uri: String
   ): Future[Option[RequestDetail]] =
     process(
       request,
-      uri = None,
-      uriOverride = Some("/individuals/field-collections/templates"),
+      uri = Some(uri),
+      uriOverride = None,
       headers = Map("CorrelationId" -> correlationId)
     )
 

--- a/app/uk/gov/hmrc/debttransformationstub/services/TTPPollingService.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/services/TTPPollingService.scala
@@ -35,7 +35,7 @@ trait TTPPollingService {
 }
 
 @Singleton
-class DefaultTTPPollingService @Inject() (ttpRequestsRepository: TTPRequestsRepository, appConfig: AppConfig)
+class DefaultTTPPollingService @Inject()(ttpRequestsRepository: TTPRequestsRepository, appConfig: AppConfig)
     extends TTPPollingService {
 
   override def insertRequestAndServeResponse(request: JsValue, uri: Option[String]): Future[Option[RequestDetail]] = {

--- a/test/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingServiceSpec.scala
+++ b/test/uk/gov/hmrc/debttransformationstub/services/DebtManagementAPIPollingServiceSpec.scala
@@ -34,11 +34,11 @@ import scala.concurrent.{ Await, Future }
 class DebtManagementAPIPollingServiceSpec extends WordSpec with Matchers with MockitoSugar {
 
   "the DebtManagementAPIPollingService" should {
-    "rewrite a URL for field collections charge, stripping path params" in {
+    "not rewrite a URL for field collections charge, stripping path params" in {
       insertRequestFor(
         env = "qa",
         inputUri = "/individuals/debts/field-collections/param1/param2/charge",
-        expectedUri = "/individuals/field-collections/charges",
+        expectedUri = "/individuals/debts/field-collections/param1/param2/charge",
         isCharge = true
       )
     }
@@ -89,7 +89,11 @@ class DebtManagementAPIPollingServiceSpec extends WordSpec with Matchers with Mo
       .thenReturn(Future.successful(Some(stubbedRequestDetail)))
     val result = {
       if (isCharge) {
-        pollingService.insertFCChargeRequestAndServeResponse(Json.obj(), "mock correlationId", "POST")
+        pollingService.insertFCChargeRequestAndServeResponse(
+          Json.obj(),
+          "mock correlationId",
+          "POST",
+          "/individuals/debts/field-collections/param1/param2/charge")
       } else {
         pollingService.insertRequestAndServeResponse(Json.obj(), inputUri)
       }


### PR DESCRIPTION
**Problem:** 
Error output of the bridge tool currently looks like this
`{
	"failures": [
		{
			"code": "BAD_IF_RESPONSE",
			"reason": "Bad response from IF; got status: 400, and got reason {\"failures\":[{\"code\":\"INVALID_CORRELATIONID\",\"reason\":\"Submission has not passed validation. Invalid header CorrelationId.\"}]}"
		}
	]
}`

**Solution:** 
Use an endpoint that calls directly to the service rather than IF -> QA -> service
This requires the stub's endpoints to be updated to match, e.g.

Old: https://api.qa.tax.service.gov.uk/individuals/field-collections/charges
New: https://admin.qa.tax.service.gov.uk/ifs/individuals/debts/field-collections/VRN/975839485/charge