### PR TITLE
DTD-1460 Enable stub return 400 or 422 using file name

### DIFF
--- a/app/uk/gov/hmrc/debttransformationstub/controllers/TimeToPayController.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/controllers/TimeToPayController.scala
@@ -128,9 +128,13 @@ class TimeToPayController @Inject() (
   def nddsEnactArrangement: Action[JsValue] = Action.async(parse.json) { implicit request =>
     val correlationId = getCorrelationIdHeader(request.headers)
     withCustomJsonBody[NDDSRequest] { req =>
+      val brocsId = req.identification
+        .find(_.idType.equalsIgnoreCase("BROCS"))
+        .map(_.idValue)
+        .getOrElse(throw new IllegalArgumentException("BROCS id is required for NDDS enact arrangement"))
       for {
         _            <- enactStageRepository.addNDDSStage(correlationId, req)
-        fileResponse <- findFile(s"/ndds.enactArrangement/", s"${req.identification.head.idValue}.json")
+        fileResponse <- findFile(s"/ndds.enactArrangement/", s"$brocsId.json")
       } yield fileResponse
     }
   }


### PR DESCRIPTION
This PR

- Allows the stub to return a status code of 400 or 422 provided the file could not be found and its name starts with `PA400` or `PA422`
- Ensures the BROCS id is used for NDDS enact arrangement