### PR TITLE
DTD-1526 Stubs etmp eligibility error 500 cases

### DIFF
--- a/conf/resources/data/etmp.eligibility.PAYE/error-500-stub.json
+++ b/conf/resources/data/etmp.eligibility.PAYE/error-500-stub.json
@@ -1,0 +1,1 @@
+// this file is designed to throw error 500 since it is invalid json

--- a/conf/resources/data/etmp.eligibility.VATC/error-500-stub.json
+++ b/conf/resources/data/etmp.eligibility.VATC/error-500-stub.json
@@ -1,0 +1,1 @@
+// this file is designed to throw error 500 since it is invalid json


### PR DESCRIPTION
This adds stubs to enable the ETMP eligibility request to return error 500.
This should help with producing an alert.