### PR TITLE
DTD-3070 "Change the address type used for the RLS check for PAYE"

### DIFF
--- a/conf/resources/data/etmp.eligibility.PAYE/eligibilityPass.json
+++ b/conf/resources/data/etmp.eligibility.PAYE/eligibilityPass.json
@@ -44,7 +44,7 @@
   },
   "addresses": [
     {
-      "addressType": "Business",
+      "addressType": "business",
       "addressLine1": "Worthing1",
       "addressLine2": "Worthing2",
       "addressLine3": "Worthing3",

--- a/conf/resources/data/etmp.eligibility.PAYE/eligibilityPass.json
+++ b/conf/resources/data/etmp.eligibility.PAYE/eligibilityPass.json
@@ -44,7 +44,7 @@
   },
   "addresses": [
     {
-      "addressType": "PPOB",
+      "addressType": "Business",
       "addressLine1": "Worthing1",
       "addressLine2": "Worthing2",
       "addressLine3": "Worthing3",

--- a/conf/resources/data/etmp.eligibility.PAYE/hasRlsOnAddressTrue.json
+++ b/conf/resources/data/etmp.eligibility.PAYE/hasRlsOnAddressTrue.json
@@ -12,7 +12,7 @@
   ],
   "addresses": [
     {
-      "addressType": "PPOB",
+      "addressType": "Business",
       "addressLine1": "Worthing1",
       "addressLine2": "Worthing2",
       "countryCode": "GB",

--- a/conf/resources/data/etmp.eligibility.PAYE/rlsAddress_true.json
+++ b/conf/resources/data/etmp.eligibility.PAYE/rlsAddress_true.json
@@ -12,7 +12,7 @@
   ],
   "addresses": [
     {
-      "addressType": "PPOB",
+      "addressType": "Business",
       "addressLine1": "Worthing1",
       "addressLine2": "Worthing2",
       "countryCode": "GB",


### PR DESCRIPTION
Change the addressType used from PPOB to 'Business' when looking for 'rls' against an address (The value must be case insensitive meaning that uppercase and lowercase are checked for.)