### PR TITLE
NOJIRA: Add plugin to check dependencies with `sbt dependencyUpdates` and `(cd project && sbt dependencyUpdates)`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
 logs
-project/project
+project/project/*
 project/target
 target
 lib_managed
@@ -23,4 +23,4 @@ npm-debug.log
 yarn-debug.log
 yarn-error.log
 
-    
+!/project/project/*.sbt

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,8 @@ addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.6")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.4")
 
+// To use this plugin, run: sbt dependencyUpdates
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")
+
 /* Allows commands like `sbt dependencyBrowseGraph` to view the dependency graph locally. */
 addDependencyTreePlugin

--- a/project/project/plugins-2.sbt
+++ b/project/project/plugins-2.sbt
@@ -1,0 +1,2 @@
+// To use this plugin, run: (cd project && sbt dependencyUpdates)
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")


### PR DESCRIPTION
Main build updates:
```
sbt dependencyUpdates

[info] Found 7 dependency updates for debt-transformation-stub
[info]   commons-io:commons-io                          : 2.18.0                      -> 20030203.000550
[info]   org.scala-lang:scala-library                   : 2.13.12 -> 2.13.16                            
[info]   org.scalatestplus.play:scalatestplus-play:test : 5.1.0                       -> 7.0.1          
[info]   uk.gov.hmrc.mongo:hmrc-mongo-play-30           : 1.6.0              -> 1.9.0 -> 2.6.0          
[info]   uk.gov.hmrc.mongo:hmrc-mongo-test-play-30:test : 1.6.0              -> 1.9.0 -> 2.6.0          
[info]   uk.gov.hmrc:bootstrap-backend-play-30          : 8.2.0              -> 8.6.0 -> 9.11.0         
[info]   uk.gov.hmrc:bootstrap-test-play-30:test        : 8.2.0              -> 8.6.0 -> 9.11.0   
```

Meta build updates:
```
(cd project && sbt dependencyUpdates)

[info] Found 3 dependency updates for project
[info]   org.playframework:sbt-plugin      : 3.0.6   -> 3.0.7             
[info]   org.scala-lang:scala-library      : 2.12.18 -> 2.12.20 -> 2.13.16
[info]   org.scala-sbt:sbt-dependency-tree : 1.9.9              -> 1.10.11

```