### PR TITLE
DTD-3670: Update jackson-core from 2.14.x to 2.19.2 due to a vulnerability.

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,11 +6,13 @@ object AppDependencies {
   val hmrcMongoPlay = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapPlay,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoPlay,
-    "com.beachape"      %% "enumeratum-play-json"      % "1.8.2",
-    "commons-io"         % "commons-io"                % "2.19.0",
-    "com.nrinaudo"      %% "kantan.csv"                % "0.8.0"
+    // This is necessary until the HMRC/Play dependencies bring in the version of Jackson that is not insecure.
+    "com.fasterxml.jackson.core" % "jackson-core"              % "2.19.2",
+    "uk.gov.hmrc"               %% "bootstrap-backend-play-30" % bootstrapPlay,
+    "uk.gov.hmrc.mongo"         %% "hmrc-mongo-play-30"        % hmrcMongoPlay,
+    "com.beachape"              %% "enumeratum-play-json"      % "1.8.2",
+    "commons-io"                 % "commons-io"                % "2.19.0",
+    "com.nrinaudo"              %% "kantan.csv"                % "0.8.0"
   )
 
   val test: Seq[ModuleID] = Seq(


### PR DESCRIPTION
Resolves [CVE-2025-52999](https://catalogue.tax.service.gov.uk/vulnerabilities?vulnerability=CVE-2025-52999).
> jackson-core contains core low-level incremental ("streaming") parser and generator abstractions used by Jackson Data Processor. In versions prior to 2.15.0, if a user parses an input file and it has deeply nested data, Jackson could end up throwing a StackoverflowError if the depth is particularly large. jackson-core 2.15.0 contains a configurable limit for how deep Jackson will traverse in an input document, defaulting to an allowable depth of 1000. jackson-core will throw a StreamConstraintsException if the limit is reached. jackson-databind also benefits from this change because it uses jackson-core to parse JSON inputs. As a workaround, users should avoid parsing input files from untrusted sources.

<img width="920" height="128" alt="Image showing how the bobby rule is marked as RED in all environments" src="https://github.com/user-attachments/assets/fdfb3530-1477-4dde-8c25-5be427d97fac" />


This was done in our other services, but we forgot about this one.

Note that in the main scope we depended on 2.14.2, but one of our test-only libraries depended on 2.14.3. Both should be fine to override with 2.19.2

Here's what the main-scope dependency graph looks like:
<img width="695" height="453" alt="Image showing how jackson-core version 2.14.3 was evicted by 2.19.2 due to the top-level dependency." src="https://github.com/user-attachments/assets/f0cb7790-bd13-4d01-b51f-de62f664e893" />
