### PR TITLE
DTD-3524: Add main and sub trans to enums

### DIFF
--- a/app/uk/gov/hmrc/debttransformationstub/models/MainTransType.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/models/MainTransType.scala
@@ -47,4 +47,11 @@ object MainTransType extends Enum[MainTransType] with PlayJsonEnum[MainTransType
   case object NIDistraintCosts extends MainTransType("1441")
   case object SAOpLed extends MainTransType("5210")
   case object SAOpLedCreatePlan extends MainTransType("4980")
+  case object PenaltyReformCharge6010 extends MainTransType("6010")
+  case object PenaltyReformCharge4027 extends MainTransType("4027")
+  case object PenaltyReformCharge4028 extends MainTransType("4028")
+  case object PenaltyReformCharge4029 extends MainTransType("4029")
+  case object PenaltyReformCharge4031 extends MainTransType("4031")
+  case object PenaltyReformCharge4032 extends MainTransType("4032")
+  case object PenaltyReformCharge4033 extends MainTransType("4033")
 }

--- a/app/uk/gov/hmrc/debttransformationstub/models/SubTransType.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/models/SubTransType.scala
@@ -41,4 +41,12 @@ object SubTransType extends Enum[SubTransType] with PlayJsonEnum[SubTransType] {
   case object TakingControlFee extends SubTransType("1150")
   case object SAOpLed extends SubTransType("1553")
   case object SAOpLedCreatePlan extends SubTransType("1090")
+  case object PenaltyReformCharge1611 extends SubTransType("1611")
+  case object PenaltyReformCharge2090 extends SubTransType("2090")
+  case object PenaltyReformCharge2095 extends SubTransType("2095")
+  case object PenaltyReformCharge2096 extends SubTransType("2096")
+  case object PenaltyReformCharge1080 extends SubTransType("1080")
+  case object PenaltyReformCharge1085 extends SubTransType("1085")
+  case object PenaltyReformCharge1090 extends SubTransType("1090")
+  case object PenaltyReformCharge1095 extends SubTransType("1095")
 }


### PR DESCRIPTION
There's an Enum in the stub that needed the new Penalty Reform Charges for the Acceptance Tests