### PR TITLE
DTD-3890 stub work to replace ITSA MigraTed to YEAR OF MIGRATION in signalType

### DIFF
--- a/conf/resources/data/sa/iTSAMigrateCesaSignalType.json
+++ b/conf/resources/data/sa/iTSAMigrateCesaSignalType.json
@@ -50,7 +50,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "cesa signal type"
       }

--- a/conf/resources/data/sa/iTSAMigrateCustomerSignalType.json
+++ b/conf/resources/data/sa/iTSAMigrateCustomerSignalType.json
@@ -50,7 +50,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "cesa signal type"
       }

--- a/conf/resources/data/sa/iTSAMigrateEtmpSignalType.json
+++ b/conf/resources/data/sa/iTSAMigrateEtmpSignalType.json
@@ -134,7 +134,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "etmp signal type"
       }

--- a/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedLiabilityAndDebt.json
+++ b/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedLiabilityAndDebt.json
@@ -119,7 +119,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "True",
         "signalDescription": "ETMP ITSA MigraTed signal type"
       }

--- a/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedLiabilityAndDebtFalse.json
+++ b/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedLiabilityAndDebtFalse.json
@@ -119,7 +119,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "ETMP ITSA MigraTed signal type"
       }

--- a/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedWithDebtNoLiability.json
+++ b/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedWithDebtNoLiability.json
@@ -134,7 +134,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "True",
         "signalDescription": "ETMP ITSA MigraTed signal type"
       }

--- a/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedWithLiabilityNoDebt.json
+++ b/conf/resources/data/sa/transitionedToCdcsAndiTSAMigratedWithLiabilityNoDebt.json
@@ -134,7 +134,7 @@
     ],
     "signals": [
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "ETMP ITSA MigraTed signal type"
       }

--- a/conf/resources/data/sa/transitionedToiTSAMigratedWithNoDebtAndLiability.json
+++ b/conf/resources/data/sa/transitionedToiTSAMigratedWithNoDebtAndLiability.json
@@ -124,12 +124,12 @@
         "signalDescription": "ETMP Transitioned to CDCS signal type"
       },
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "ETMP ITSA MigraTed signal type"
       },
       {
-        "signalType": "ITSA MigraTed",
+        "signalType": "YEAR OF MIGRATION",
         "signalValue": "2024",
         "signalDescription": "ETMP ITSA MigraTed signal type"
       }


### PR DESCRIPTION
Replaced ITSA MigraTed to YEAR OF MIGRATION signalType for MTD(ITSA) customerType in stub.
All tests pass
<img width="336" height="35" alt="image" src="https://github.com/user-attachments/assets/1267a34d-9284-4a94-89af-a128e8404877" />
