### PR TITLE
DTD-4458 - Added 400 error response to smoke test new CDCS schema change

### DIFF
--- a/app/uk/gov/hmrc/debttransformationstub/controllers/CDCSController.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/controllers/CDCSController.scala
@@ -38,6 +38,7 @@ class CDCSController @Inject() (environment: Environment, cc: ControllerComponen
     withCustomJsonBody[CdcsRequest] { request =>
       val fileName: String = request.identifications.head.idValue
       val relativePath = s"$basePath" + "/" + s"$fileName.json"
+      logger.info(s"***** \n\n\nPATH: $relativePath")
       environment.getExistingFile(relativePath) match {
         case None =>
           val message = s"file [$relativePath] not found"
@@ -54,7 +55,13 @@ class CDCSController @Inject() (environment: Environment, cc: ControllerComponen
           maybeFileContent match {
             case Success(value) =>
               // Might throw if parsing fails
-              Future.successful(Ok(Json.parse(value)))
+              val json = Json.parse(value)
+              val result = file.getName match {
+                case "cdcsClientError400.json" => BadRequest(json)
+                case _                                => Ok(json)
+              }
+              logger.info(s"*******************CDCS RESPONSE*****\n\n\n$json\n\n\n")
+              Future.successful(result)
             case Failure(exception) =>
               logger.error(s"Failed to parse the file $file", exception)
               Future.successful(InternalServerError(s"Stub failed to parse file $file"))

--- a/app/uk/gov/hmrc/debttransformationstub/controllers/CDCSController.scala
+++ b/app/uk/gov/hmrc/debttransformationstub/controllers/CDCSController.scala
@@ -38,7 +38,6 @@ class CDCSController @Inject() (environment: Environment, cc: ControllerComponen
     withCustomJsonBody[CdcsRequest] { request =>
       val fileName: String = request.identifications.head.idValue
       val relativePath = s"$basePath" + "/" + s"$fileName.json"
-      logger.info(s"***** \n\n\nPATH: $relativePath")
       environment.getExistingFile(relativePath) match {
         case None =>
           val message = s"file [$relativePath] not found"
@@ -58,9 +57,8 @@ class CDCSController @Inject() (environment: Environment, cc: ControllerComponen
               val json = Json.parse(value)
               val result = file.getName match {
                 case "cdcsClientError400.json" => BadRequest(json)
-                case _                                => Ok(json)
+                case _                         => Ok(json)
               }
-              logger.info(s"*******************CDCS RESPONSE*****\n\n\n$json\n\n\n")
               Future.successful(result)
             case Failure(exception) =>
               logger.error(s"Failed to parse the file $file", exception)

--- a/conf/resources/data/cdcs/cdcsClientError400.json
+++ b/conf/resources/data/cdcs/cdcsClientError400.json
@@ -1,0 +1,6 @@
+{
+  "processingDateTime": "2024-02-28T11:43:56Z",
+  "error": {
+    "description": "Invalid Request"
+  }
+}

--- a/conf/resources/data/sa/cdcsClientError400.json
+++ b/conf/resources/data/sa/cdcsClientError400.json
@@ -1,0 +1,192 @@
+{
+  "cesaData": {
+    "customer": {
+      "individual": {
+        "title": "Mr",
+        "firstName": "Ben",
+        "lastName": "Thomas",
+        "dateOfBirth": "2014-09-12",
+        "dateOfDeath": "2014-09-12",
+        "identifications": [
+          {
+            "idType": "UTR",
+            "idValue": "cdcsClientError400"
+          }
+        ]
+      }
+    },
+    "addresses": [
+      {
+        "addressType": "PPOB",
+        "rls": false,
+        "addressLine1": "string",
+        "emailAddress": "joe@snailmail.com",
+        "postcodeHistory": [
+          {
+            "addressPostcode": "BN127ER",
+            "postcodeDate": "2022-05-22"
+          },
+          {
+            "addressPostcode": "BN129ER",
+            "postcodeDate": "2022-02-28"
+          },
+          {
+            "addressPostcode": "BN119ER",
+            "postcodeDate": "2001-01-31"
+          }
+        ]
+      },
+      {
+        "addressType": "AGENT",
+        "rls": false,
+        "addressLine1": "string",
+        "postcodeHistory": [
+          {
+            "addressPostcode": "BN164QR",
+            "postcodeDate": "2022-03-02"
+          }
+        ]
+      }
+    ],
+    "signals": [
+      {
+        "signalType": "Transitioned to CDCS",
+        "signalValue": "True",
+        "signalDescription": ""
+      }
+    ],
+    "filings": [
+      {
+        "icrCategory": "string",
+        "icrDescription": "string",
+        "fromDate": "2014-09-12",
+        "toDate": "2014-09-12",
+        "dueDate": "2014-09-12"
+      }
+    ],
+    "charges": [
+      {
+        "chargeType": "In Year RTI Charge - Tax",
+        "mainType": "In Year RTI Charge (FPS)",
+        "mainTrans": "4000",
+        "subTrans": "1005",
+        "UTR": "73",
+        "taxPeriodFrom": "2022-02-06",
+        "taxPeriodTo": "2022-03-05",
+        "dueDate": "<DUE_DATE>",
+        "interestStartDate": "2022-03-05",
+        "tieBreaker": "4321",
+        "creationDate": "2022-03-05",
+        "saTaxYearEnd": "2022-03-05",
+        "originalChargeType": "string",
+        "originalTieBreaker": "1234",
+        "chargeReference": "XM123456789812",
+        "outstandingAmount": 3000.00,
+        "accruedInterest": 500.00
+      }
+    ],
+    "responseCode": {
+      "timestamp": "2024-03-28T13:43:56.235Z",
+      "httpCode": 200
+    }
+  },
+  "etmpData": {
+    "customer": {
+      "individual": {
+        "title": "Mr",
+        "firstName": "Ben",
+        "lastName": "Thomas",
+        "dateOfBirth": "2014-09-12",
+        "dateOfDeath": "2014-09-12",
+        "identifications": [
+          {
+            "idType": "UTR",
+            "idValue": "cdcsClientError400"
+          }
+        ]
+      }
+    },
+    "addresses": [
+      {
+        "addressType": "PPOB",
+        "rls": false,
+        "addressLine1": "string",
+        "emailAddress": "joe@snailmail.com",
+        "postcodeHistory": [
+          {
+            "addressPostcode": "BN127ER",
+            "postcodeDate": "2022-05-22"
+          },
+          {
+            "addressPostcode": "BN129ER",
+            "postcodeDate": "2022-02-28"
+          },
+          {
+            "addressPostcode": "BN119ER",
+            "postcodeDate": "2001-01-31"
+          }
+        ]
+      },
+      {
+        "addressType": "AGENT",
+        "rls": false,
+        "addressLine1": "string",
+        "postcodeHistory": [
+          {
+            "addressPostcode": "BN164QR",
+            "postcodeDate": "2022-03-02"
+          }
+        ]
+      }
+    ],
+    "signals": [
+      {
+        "signalType": "Transitioned to CDCS",
+        "signalValue": "True",
+        "signalDescription": ""
+      }
+    ],
+    "filings": [
+      {
+        "icrCategory": "ZR01",
+        "icrDescription": "RTI - PAYE - Monthly Returns",
+        "fromDate": "2022-03-06",
+        "toDate": "2022-04-05",
+        "dueDate": "2022-04-22"
+      },
+      {
+        "icrCategory": "ZR01",
+        "icrDescription": "RTI - PAYE - Monthly Returns",
+        "fromDate": "2022-04-06",
+        "toDate": "2022-05-05",
+        "dueDate": "2022-05-22"
+      }
+    ],
+    "charges": [
+      {
+        "chargeType": "In Year RTI Charge - Tax",
+        "mainType": "In Year RTI Charge (FPS)",
+        "mainTrans": "4000",
+        "subTrans": "1005",
+        "UTR": "73",
+        "taxPeriodFrom": "2022-02-06",
+        "taxPeriodTo": "2022-03-05",
+        "chargeReference": "XM123456789813",
+        "dueDate": "<DUE_DATE>",
+        "interestStartDate": "2022-03-05",
+        "outstandingAmount": 1000.00,
+        "accruedInterest": 50.00,
+        "locks": [
+        ]
+      }
+    ],
+    "responseCode": {
+      "timestamp": "2024-03-28T13:43:56.235Z",
+      "httpCode": 200
+    }
+  },
+  "responseCode": {
+    "timestamp": "2024-03-28T13:43:56.235Z",
+    "httpCode": 200
+  }
+}


### PR DESCRIPTION
I need to smoke test the new changes CDCS have made to the schema. I've been able to smoke test the happy path with `resources/data/cdcs/cdcsClientError400.json` but not when CDCS responds with a 400 status code as there's no file in the stub for this. To get this out today and ready for them to test, I am adding this now however, this will need to be added as an AT test